### PR TITLE
Extending rss generation for rough Podcast support

### DIFF
--- a/fastapi_rss/models/feed.py
+++ b/fastapi_rss/models/feed.py
@@ -37,7 +37,6 @@ class RSSFeed(BaseModel):
 
     item: List[Item] = []
 
-    ##
     @staticmethod
     def generate_tree(root, dict_):  # TODO: improve that shiete
         for key, value in dict_.items():

--- a/fastapi_rss/models/item.py
+++ b/fastapi_rss/models/item.py
@@ -7,6 +7,7 @@ from fastapi_rss.models.category import Category
 from fastapi_rss.models.enclosure import Enclosure
 from fastapi_rss.models.guid import GUID
 from fastapi_rss.models.source import Source
+from fastapi_rss.models.itunes import Itunes
 
 
 class Item(BaseModel):
@@ -20,3 +21,4 @@ class Item(BaseModel):
     guid: Optional[GUID]
     pub_date: Optional[datetime.datetime]
     source: Optional[Source]
+    itunes: Optional[Itunes]

--- a/fastapi_rss/models/itunes.py
+++ b/fastapi_rss/models/itunes.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from pydantic import BaseModel
+
+class ItunesAttrs(BaseModel):
+    href: str
+
+class Itunes(BaseModel):
+    content: str
+    attrs: Optional[ItunesAttrs]


### PR DESCRIPTION
Hello, thanks for this awesome project! :slightly_smiling_face: 

I recently used it as a part of generating an rss feed after parsing them to combine into one master list for [my projects](https://github.com/elreydetoda/all-linux-tings/blob/896206bc4beda886a8fb328f9cdbcb28957eb1eb/apis/rssaggregator/app/), and while using it I ended up adding [some overrides](https://github.com/elreydetoda/all-linux-tings/blob/896206bc4beda886a8fb328f9cdbcb28957eb1eb/apis/rssaggregator/app/generator_override.py) for the generator. Just so I could encode specific values for the podcasts ( i.e. their cover art for the episode ).

This definitely comprehensive podcast support, but I was just grabbing the small things that I was using so far. Just figured I would toss it your way if you want it. If not, I already have my overrides :slightly_smiling_face: