### PR TITLE
Pydantic 2 Compatibility: Default values for `Optional` fields

### DIFF
--- a/fastapi_rss/models/category.py
+++ b/fastapi_rss/models/category.py
@@ -11,7 +11,7 @@ class CategoryAttrs(BaseModel):
 
     Processors may establish conventions for the interpretation of categories
     '''
-    domain: Optional[str]
+    domain: Optional[str] = None
 
 
 class Category(BaseModel):
@@ -19,4 +19,4 @@ class Category(BaseModel):
     An optional sub-element of a channel or an item
     '''
     content: str
-    attrs: Optional[CategoryAttrs]
+    attrs: Optional[CategoryAttrs] = None

--- a/fastapi_rss/models/cloud.py
+++ b/fastapi_rss/models/cloud.py
@@ -4,12 +4,12 @@ from pydantic import BaseModel
 
 
 class CloudAttrs(BaseModel):
-    domain: Optional[str]
-    port: Optional[str]
-    path: Optional[str]
-    register_procedure: Optional[str]
-    protocol: Optional[str]
+    domain: Optional[str] = None
+    port: Optional[str] = None
+    path: Optional[str] = None
+    register_procedure: Optional[str] = None
+    protocol: Optional[str] = None
 
 
 class Cloud(BaseModel):
-    attrs: Optional[CloudAttrs]
+    attrs: Optional[CloudAttrs] = None

--- a/fastapi_rss/models/feed.py
+++ b/fastapi_rss/models/feed.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from fastapi import __version__ as faversion
 from lxml import etree
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from fastapi_rss import __version__ as farssversion
 from fastapi_rss.models.category import Category
@@ -21,22 +21,22 @@ class RSSFeed(BaseModel):
     description: str
 
     language: Optional[str] = get_locale_code()
-    copyright: Optional[str]
-    managing_editor: Optional[str]
-    webmaster: Optional[str]
-    pub_date: Optional[datetime]
-    last_build_date: Optional[datetime]
-    category: Optional[List[Category]]
+    copyright: Optional[str] = None
+    managing_editor: Optional[str] = None
+    webmaster: Optional[str] = None
+    pub_date: Optional[datetime] = None
+    last_build_date: Optional[datetime] = None
+    category: Optional[List[Category]] = Field(default_factory=list)
     generator: str = f'FastAPI v{faversion} w/ FastAPI_RSS v{farssversion}'
     docs: str = 'https://validator.w3.org/feed/docs/rss2.html'
-    cloud: Optional[Cloud]
+    cloud: Optional[Cloud] = None
     ttl: int = 60
-    image: Optional[Image]
-    text_input: Optional[TextInput]
-    skip_hours: List[int] = []
-    skip_days: List[str] = []
+    image: Optional[Image] = None
+    text_input: Optional[TextInput] = None
+    skip_hours: List[int] = Field(default_factory=list)
+    skip_days: List[str] = Field(default_factory=list)
 
-    item: List[Item] = []
+    item: List[Item] = Field(default_factory=list)
 
     @staticmethod
     def _get_attrs(value: Union[dict, BaseModel]) -> Dict[str, str]:

--- a/fastapi_rss/models/guid.py
+++ b/fastapi_rss/models/guid.py
@@ -9,4 +9,4 @@ class GUIDAttrs(BaseModel):
 
 class GUID(BaseModel):
     content: str
-    attrs: Optional[GUIDAttrs]
+    attrs: Optional[GUIDAttrs] = None

--- a/fastapi_rss/models/image.py
+++ b/fastapi_rss/models/image.py
@@ -8,6 +8,6 @@ class Image(BaseModel):
     title: str
     link: str
 
-    width: Optional[int]
-    height: Optional[int]
-    description: Optional[str]
+    width: Optional[int] = None
+    height: Optional[int] = None
+    description: Optional[str] = None

--- a/fastapi_rss/models/item.py
+++ b/fastapi_rss/models/item.py
@@ -12,13 +12,13 @@ from fastapi_rss.models.source import Source
 
 class Item(BaseModel):
     title: str
-    link: Optional[str]
-    description: Optional[str]
-    author: Optional[str]
-    category: Optional[Category]
-    comments: Optional[str]
-    enclosure: Optional[Enclosure]
-    guid: Optional[GUID]
-    pub_date: Optional[datetime.datetime]
-    source: Optional[Source]
-    itunes: Optional[Itunes]
+    link: Optional[str] = None
+    description: Optional[str] = None
+    author: Optional[str] = None
+    category: Optional[Category] = None
+    comments: Optional[str] = None
+    enclosure: Optional[Enclosure] = None
+    guid: Optional[GUID] = None
+    pub_date: Optional[datetime.datetime] = None
+    source: Optional[Source] = None
+    itunes: Optional[Itunes] = None

--- a/fastapi_rss/models/itunes.py
+++ b/fastapi_rss/models/itunes.py
@@ -9,4 +9,4 @@ class ItunesAttrs(BaseModel):
 
 class Itunes(BaseModel):
     content: str
-    attrs: Optional[ItunesAttrs]
+    attrs: Optional[ItunesAttrs] = None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,47 @@
+import inspect
+from importlib.metadata import version
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import BaseModel
+if TYPE_CHECKING:
+    from pydantic.fields import ModelField
+
+from fastapi_rss.models import (
+    Category, CategoryAttrs,
+    Image,
+    ItunesAttrs, Itunes,
+    Cloud, CloudAttrs,
+    Item,
+    TextInput,
+    Enclosure, EnclosureAttrs,
+    GUID, GUIDAttrs,
+    Source, SourceAttrs,
+    RSSFeed
+)
+
+MODELS = [i for i in locals().values() if inspect.isclass(i) and issubclass(i, BaseModel)]
+
+@pytest.mark.parametrize('model',MODELS)
+def test_optionals_have_defaults(model):
+    pydantic_major = int(version('pydantic').split('.')[0])
+
+    if pydantic_major >= 2:
+        fields = model.model_fields
+    else:
+        fields = model.__fields__
+
+    field: 'ModelField'
+    for name, field in fields.items():
+        if not field.required:
+            assert field.field_info.default is None
+
+def test_instantiate_optionals():
+    feed = RSSFeed(
+        title="My Feed",
+        link="https://example.com",
+        description="A feed!"
+    )
+    item = Item(
+        title="My Item"
+    )


### PR DESCRIPTION
FastAPI is now compatible with Pydantic 2: https://github.com/tiangolo/fastapi/discussions/9709

and eventually it like everything else will drop support for Pydantic 1.

There was a breaking change in Pydantic 2 re: how `Optional` fields are handled - previously you didn't need to supply a default value, but now according to the [migration guide](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields) `Optional[type]` is actually a required field that can be `None`, and you need to convert to `Optional[type] = None` to preserve the old behavior.

This currently breaks treating fields as optional for people using pydantic 2, which is now the default since this repo doesn't pin pydantic and doesn't have an upper bound.

Added `None` defaults for all `Optional` fields in models with regression tests, and along the way i also fixed the list literals that are [mutable default values](https://docs.python.org/3/library/dataclasses.html#mutable-default-values) and turned them into Fields with `default_factory`